### PR TITLE
Mini messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.SlimeDog</groupId>
   <artifactId>SlimeDogCore</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.4-SNAPSHOT</version>
   <name>SlimeDogCore</name>
   <description>SlimeDog core</description>
   <inceptionYear>2022</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,24 @@
 			<version>3.12.0</version>
 			<scope>provided</scope>
 		</dependency>
+    <dependency>
+      <groupId>net.kyori</groupId>
+      <artifactId>adventure-api</artifactId>
+      <version>4.13.1</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.kyori</groupId>
+      <artifactId>adventure-text-minimessage</artifactId>
+      <version>4.13.1</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.kyori</groupId>
+      <artifactId>adventure-platform-bukkit</artifactId>
+      <version>4.3.0</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -97,6 +115,34 @@
                         </goals>
                 </execution>
         </executions>
+      </plugin>
+      <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>3.4.1</version>
+          <configuration>
+              <relocations>
+                  <relocation>
+                      <pattern>net.kyori</pattern>
+                      <shadedPattern>dev.ratas.slimedogcore.shade.kyori</shadedPattern>
+                  </relocation>
+              </relocations>
+          </configuration>
+          <executions>
+              <execution>
+                  <phase>package</phase>
+                  <goals>
+                      <goal>shade</goal>
+                  </goals>
+                  <configuration>
+                      <createDependencyReducedPom>false</createDependencyReducedPom>
+                      <minimizeJar>true</minimizeJar>
+                      <transformers>
+                          <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"></transformer>
+                      </transformers>
+                  </configuration>
+              </execution>
+          </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.SlimeDog</groupId>
   <artifactId>SlimeDogCore</artifactId>
-  <version>1.0.4</version>
+  <version>1.0.5</version>
   <name>SlimeDogCore</name>
   <description>SlimeDog core</description>
   <inceptionYear>2022</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.SlimeDog</groupId>
   <artifactId>SlimeDogCore</artifactId>
-  <version>1.0.4-SNAPSHOT</version>
+  <version>1.0.4</version>
   <name>SlimeDogCore</name>
   <description>SlimeDog core</description>
   <inceptionYear>2022</inceptionYear>

--- a/src/main/java/dev/ratas/slimedogcore/impl/SlimeDogCore.java
+++ b/src/main/java/dev/ratas/slimedogcore/impl/SlimeDogCore.java
@@ -30,6 +30,7 @@ import dev.ratas.slimedogcore.impl.wrappers.PluginInformation;
 import dev.ratas.slimedogcore.impl.wrappers.PluginManager;
 import dev.ratas.slimedogcore.impl.wrappers.ResourceProvider;
 import dev.ratas.slimedogcore.impl.wrappers.WorldProvider;
+import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 
 public abstract class SlimeDogCore extends JavaPlugin implements SlimeDogPlugin {
     private static final long BLOCK_IDENTICAL_DEBUG_MSG_MS = 10 * 1000L;
@@ -46,6 +47,7 @@ public abstract class SlimeDogCore extends JavaPlugin implements SlimeDogPlugin 
     private final SDCRecipient console = new MessageRecipient(getServer().getConsoleSender());
     private final SDCOnlinePlayerProvider onlinePlayerProvider = new OnlinePlayerProvider(this);
     private final SDCReloadManager reloadManager = new ReloadManager();
+    private BukkitAudiences audience;
 
     public SlimeDogCore(JavaPluginLoader loader, PluginDescriptionFile description, File dataFolder, File file) {
         super(loader, description, dataFolder, file);
@@ -62,6 +64,11 @@ public abstract class SlimeDogCore extends JavaPlugin implements SlimeDogPlugin 
     @Override
     public void onEnable() {
         pluginEnabled();
+        audience = BukkitAudiences.create(this);
+    }
+
+    public BukkitAudiences getAudiences() {
+        return audience;
     }
 
     @Override

--- a/src/main/java/dev/ratas/slimedogcore/impl/messaging/IllegalMessageException.java
+++ b/src/main/java/dev/ratas/slimedogcore/impl/messaging/IllegalMessageException.java
@@ -1,0 +1,12 @@
+package dev.ratas.slimedogcore.impl.messaging;
+
+import dev.ratas.slimedogcore.api.reload.ReloadException;
+import dev.ratas.slimedogcore.api.reload.SDCReloadable;
+
+public class IllegalMessageException extends ReloadException {
+
+    public IllegalMessageException(SDCReloadable reloadable, String msg) {
+        super(reloadable, msg);
+    }
+
+}

--- a/src/main/java/dev/ratas/slimedogcore/impl/messaging/factory/MessageFactory.java
+++ b/src/main/java/dev/ratas/slimedogcore/impl/messaging/factory/MessageFactory.java
@@ -16,6 +16,10 @@ public class MessageFactory<T extends SDCContext> extends AbstractMessageFactory
         this.msgTarget = msgTarget;
     }
 
+    public String getRawMessage() {
+        return raw;
+    }
+
     @Override
     public SDCMessage<T> getMessage(T context) {
         return new ContextMessage<>(raw, context, msgTarget);

--- a/src/main/java/dev/ratas/slimedogcore/impl/messaging/mini/MiniMessageUtil.java
+++ b/src/main/java/dev/ratas/slimedogcore/impl/messaging/mini/MiniMessageUtil.java
@@ -1,0 +1,28 @@
+package dev.ratas.slimedogcore.impl.messaging.mini;
+
+import org.apache.commons.lang3.StringUtils;
+
+public final class MiniMessageUtil {
+
+    private MiniMessageUtil() {
+        // prviate constructor
+    }
+
+    public static boolean textCouldBeMiniMessage(String raw) {
+        // if it doesn't contain angle brackets, clearly not a mini-message
+        if (!raw.contains("<")) {
+            return false;
+        }
+        // if it has a different number of start and end brackets, not a
+        // (correctly formated) mini-message
+        if (StringUtils.countMatches(raw, "<") != StringUtils.countMatches(raw, ">")) {
+            return false;
+        }
+        // if the first < is after the first >, it's _probably_ not a minimessage
+        if (raw.indexOf("<") > raw.indexOf(">")) {
+            return false;
+        }
+        return true;
+    }
+    
+}

--- a/src/main/java/dev/ratas/slimedogcore/impl/messaging/mini/MiniMessageUtil.java
+++ b/src/main/java/dev/ratas/slimedogcore/impl/messaging/mini/MiniMessageUtil.java
@@ -24,5 +24,5 @@ public final class MiniMessageUtil {
         }
         return true;
     }
-    
+
 }

--- a/src/main/java/dev/ratas/slimedogcore/impl/messaging/mini/MiniMessageUtil.java
+++ b/src/main/java/dev/ratas/slimedogcore/impl/messaging/mini/MiniMessageUtil.java
@@ -1,8 +1,12 @@
 package dev.ratas.slimedogcore.impl.messaging.mini;
 
-import org.apache.commons.lang3.StringUtils;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public final class MiniMessageUtil {
+    private static final Pattern LEFT_ANGLE_BRACKET = Pattern.compile("(?<=\\)b<");
+    private static final Pattern RIGHT_ANGLE_BRACKET = Pattern.compile("(?<=\\)b>");
 
     private MiniMessageUtil() {
         // prviate constructor
@@ -10,16 +14,23 @@ public final class MiniMessageUtil {
 
     public static boolean textCouldBeMiniMessage(String raw) {
         // if it doesn't contain angle brackets, clearly not a mini-message
-        if (!raw.contains("<")) {
+        Matcher leftMatcher = LEFT_ANGLE_BRACKET.matcher(raw);
+        if (!leftMatcher.find()) {
             return false;
         }
         // if it has a different number of start and end brackets, not a
         // (correctly formated) mini-message
-        if (StringUtils.countMatches(raw, "<") != StringUtils.countMatches(raw, ">")) {
+        Matcher rightMatcher = RIGHT_ANGLE_BRACKET.matcher(raw);
+        // 1 already counted above with #find
+        long totalLeftMatches = leftMatcher.results().count() + 1;
+        long totalRightMatches = rightMatcher.results().count();
+        if (totalLeftMatches != totalRightMatches) {
             return false;
         }
         // if the first < is after the first >, it's _probably_ not a minimessage
-        if (raw.indexOf("<") > raw.indexOf(">")) {
+        MatchResult firstLeft = leftMatcher.reset().results().findFirst().get();
+        MatchResult firstRight = rightMatcher.reset().results().findFirst().get();
+        if (firstLeft.start() > firstRight.start()) {
             return false;
         }
         return true;

--- a/src/main/java/dev/ratas/slimedogcore/impl/messaging/mini/MiniMessageUtil.java
+++ b/src/main/java/dev/ratas/slimedogcore/impl/messaging/mini/MiniMessageUtil.java
@@ -5,8 +5,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public final class MiniMessageUtil {
-    private static final Pattern LEFT_ANGLE_BRACKET = Pattern.compile("(?<=\\)b<");
-    private static final Pattern RIGHT_ANGLE_BRACKET = Pattern.compile("(?<=\\)b>");
+    private static final Pattern LEFT_ANGLE_BRACKET = Pattern.compile("(?<!\\\\)\\<");
+    private static final Pattern RIGHT_ANGLE_BRACKET = Pattern.compile("(?<!\\\\)\\>");
 
     private MiniMessageUtil() {
         // prviate constructor

--- a/src/test/java/dev/ratas/slimedogcore/impl/messaging/MiniMessageDetectionTest.java
+++ b/src/test/java/dev/ratas/slimedogcore/impl/messaging/MiniMessageDetectionTest.java
@@ -1,0 +1,58 @@
+package dev.ratas.slimedogcore.impl.messaging;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import dev.ratas.slimedogcore.impl.messaging.mini.MiniMessageUtil;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+
+public class MiniMessageDetectionTest {
+    private static final String VERY_RAW_MESSAGE = "This message does not contain any formating";
+    private static final String CORRECT_MINIMESSAGE_1 = "<yellow>Hello <blue>World<yellow>!";
+    // with "placeholder"
+    private static final String CORRECT_MINIMESSAGE_2 = "<yellow>Hello </yellow><blue>%player%</blue><yellow>!</yellow>";
+    // i.e with escapes
+    private static final String CORRECT_MINIMESSAGE_3 = "<yellow>Bigger than (<blue>\\><yellow>)";
+    // no matches
+    private static final String INCORRECT_1 = "<something<< what ever>";
+    // matches but starts with greater than
+    private static final String INCORRECT_2 = "> some <";
+
+    @Test
+    public void testRawMessageIsNot() {
+        Assertions.assertFalse(MiniMessageUtil.textCouldBeMiniMessage(VERY_RAW_MESSAGE));
+    }
+
+    private void checkIsAndDeserialize(String raw) {
+        Assertions.assertTrue(MiniMessageUtil.textCouldBeMiniMessage(raw));
+        MiniMessage.miniMessage().deserialize(raw); // would throw exception if incorrect format
+    }
+
+    @Test
+    public void testCorrectMiniMessageWorks() {
+        checkIsAndDeserialize(CORRECT_MINIMESSAGE_1);
+        ;
+    }
+
+    @Test
+    public void testCorrectWithPlaceholderWorks() {
+        checkIsAndDeserialize(CORRECT_MINIMESSAGE_2);
+    }
+
+    @Test
+    public void testCorrectWithEscapeWorks() {
+        checkIsAndDeserialize(CORRECT_MINIMESSAGE_3);
+    }
+
+    @Test
+    public void doesNotWorkWithIncorrectMatching() {
+        Assertions.assertFalse(MiniMessageUtil.textCouldBeMiniMessage(INCORRECT_1));
+    
+    }
+
+    @Test
+    public void doesNotWorkWithIncorrectOrder() {
+        Assertions.assertFalse(MiniMessageUtil.textCouldBeMiniMessage(INCORRECT_2));
+    }
+
+}


### PR DESCRIPTION
Add minimessages to address #12.

This will mean that any and all plugins supporting this (or a future) release will be able to use a the minimessage format messaging.

SDC will try to parse a minimessage if (and only if) the raw message:
1. Has an equal (and nonzero) number of `<` and `>` characters
2. The first `<` is before the first `>`

Now, the above is not really an exhaustive way of determine if a raw message is in the correct format. For instance, the raw string "Please include the world name in the command: /see info <world>" would be identified as a minimessage.
But I don't really know what an exhaustive approach would look like.

